### PR TITLE
FIX : use "organization" instead of "organisation" for consistency

### DIFF
--- a/src/Controller/Client.php
+++ b/src/Controller/Client.php
@@ -15,11 +15,11 @@ class Client {
         $this->secretKey = $secretKey;
     }
 
-    public function getOrganisation() {
+    public function getOrganization() {
         $organization = new Organization();
-        $organization->setLoginApi($this->loginApi)
+        return $organization->setLoginApi($this->loginApi)
                      ->setSecretKey($this->secretKey)
-                     ->getOrganisation();
+                     ->getOrganization();
     }
 
 

--- a/src/Model/Organization.php
+++ b/src/Model/Organization.php
@@ -6,8 +6,8 @@ use QontoClient\Model\ApiModel;
 use QontoClient\Entity\Organization as OrganizationEntity;
 
 class Organization extends ApiModel {
-    
-    public function getOrganisation() {
+
+    public function getOrganization() {
         $data = $this->callApi('GET','organizations/' . $this->loginApi);
 
         $organization = new OrganizationEntity();


### PR DESCRIPTION
Hi !

Here's a quick fix for name consistency... 

Are you still maintining this  API client ? Are interested by more Pull Requests ?

